### PR TITLE
Refactor service helpers.

### DIFF
--- a/src/main/java/homewatch/server/controllers/ServiceHelper.java
+++ b/src/main/java/homewatch/server/controllers/ServiceHelper.java
@@ -12,6 +12,9 @@ import homewatch.things.lights.HueLightService;
 import spark.QueryParamsMap;
 import spark.Request;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class ServiceHelper<T> {
   private final ThingServiceFactory<T> serviceFactory;
 
@@ -25,13 +28,7 @@ public class ServiceHelper<T> {
 
       ThingService<T> thingService = serviceFactory.create(info.getSubType());
 
-      if (thingService instanceof HttpThingService) {
-        this.httpService(thingService, req);
-      }
-
-      if (thingService instanceof HueLightService) {
-        this.hueLightService(thingService, req);
-      }
+      thingService.setAttributes(convertQueryMap(req.queryMap()));
 
       return thingService;
     } catch (InvalidSubTypeException e) {
@@ -40,20 +37,12 @@ public class ServiceHelper<T> {
     }
   }
 
-  private void httpService(ThingService<T> thingService, Request req) {
-    HttpThingInfo httpThingInfo = HttpThingInfo.fromQueryString(req.queryMap());
+  private Map<String, String> convertQueryMap(QueryParamsMap queryMap){
+    Map<String, String[]> mapStringArray = queryMap.toMap();
+    Map<String, String> map = new HashMap<>();
 
-    HttpThingService<T> httpThingService = (HttpThingService<T>) thingService;
-    httpThingService.setAddress(httpThingInfo.getAddress());
-    httpThingService.setPort(httpThingInfo.getPort());
-  }
+    mapStringArray.forEach((k,v) -> map.put(k, v[0]));
 
-  private void hueLightService(ThingService<T> thingService, Request req) {
-    QueryParamsMap lightIdParam = req.queryMap().get("light_id");
-
-    if (!lightIdParam.hasValue())
-      throw new IllegalArgumentException("missing light_id");
-    HueLightService hueLightService = (HueLightService) thingService;
-    hueLightService.setLightID(lightIdParam.integerValue());
+    return map;
   }
 }

--- a/src/main/java/homewatch/server/controllers/ServiceHelper.java
+++ b/src/main/java/homewatch/server/controllers/ServiceHelper.java
@@ -3,12 +3,9 @@ package homewatch.server.controllers;
 import homewatch.constants.LoggerUtils;
 import homewatch.exceptions.InvalidSubTypeException;
 import homewatch.exceptions.NetworkException;
-import homewatch.server.pojos.HttpThingInfo;
 import homewatch.server.pojos.ThingInfo;
-import homewatch.things.HttpThingService;
 import homewatch.things.ThingService;
 import homewatch.things.ThingServiceFactory;
-import homewatch.things.lights.HueLightService;
 import spark.QueryParamsMap;
 import spark.Request;
 
@@ -37,11 +34,11 @@ public class ServiceHelper<T> {
     }
   }
 
-  private Map<String, String> convertQueryMap(QueryParamsMap queryMap){
+  private Map<String, String> convertQueryMap(QueryParamsMap queryMap) {
     Map<String, String[]> mapStringArray = queryMap.toMap();
     Map<String, String> map = new HashMap<>();
 
-    mapStringArray.forEach((k,v) -> map.put(k, v[0]));
+    mapStringArray.forEach((k, v) -> map.put(k, v[0]));
 
     return map;
   }

--- a/src/main/java/homewatch/things/HttpThingService.java
+++ b/src/main/java/homewatch/things/HttpThingService.java
@@ -37,7 +37,7 @@ public abstract class HttpThingService<T> extends ThingService<T> {
   }
 
   @Override
-  public void setAttributes(Map<String, ? extends Object> attributes) {
+  public void setAttributes(Map<String, ?> attributes) {
     String address = this.getAttribute(attributes, "address", String.class);
     String port = this.getAttribute(attributes, "port", String.class);
 
@@ -47,7 +47,7 @@ public abstract class HttpThingService<T> extends ThingService<T> {
 
     try {
       this.address = InetAddress.getByName(address);
-      this.port = (port == null) ? null : Integer.parseInt((String) port);
+      this.port = (port == null) ? null : Integer.parseInt(port);
     } catch (UnknownHostException ex) {
       throw new IllegalArgumentException(ex);
     } catch (NumberFormatException ex) {

--- a/src/main/java/homewatch/things/HttpThingService.java
+++ b/src/main/java/homewatch/things/HttpThingService.java
@@ -1,8 +1,10 @@
 package homewatch.things;
 
 import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Map;
 
-public abstract class HttpThingService<T> implements ThingService<T> {
+public abstract class HttpThingService<T> extends ThingService<T> {
   private InetAddress address;
   private Integer port = null;
 
@@ -32,6 +34,25 @@ public abstract class HttpThingService<T> implements ThingService<T> {
 
   public void setPort(Integer port) {
     this.port = port;
+  }
+
+  @Override
+  public void setAttributes(Map<String, ? extends Object> attributes) {
+    String address = this.getAttribute(attributes, "address", String.class);
+    String port = this.getAttribute(attributes, "port", String.class);
+
+    if (address == null) {
+      throw new IllegalArgumentException("missing address");
+    }
+
+    try {
+      this.address = InetAddress.getByName(address);
+      this.port = (port == null) ? null : Integer.parseInt((String) port);
+    } catch (UnknownHostException ex) {
+      throw new IllegalArgumentException(ex);
+    } catch (NumberFormatException ex) {
+      throw new IllegalArgumentException("invalid port");
+    }
   }
 
   protected String getUrl() {

--- a/src/main/java/homewatch/things/ThingService.java
+++ b/src/main/java/homewatch/things/ThingService.java
@@ -2,14 +2,32 @@ package homewatch.things;
 
 import homewatch.exceptions.NetworkException;
 
-public interface ThingService<T> {
-  T get() throws NetworkException;
+import java.util.Map;
 
-  T put(T t) throws NetworkException;
+public abstract class ThingService<T> {
+  public abstract T get() throws NetworkException;
 
-  boolean ping();
+  public abstract T put(T t) throws NetworkException;
 
-  String getType();
+  public abstract boolean ping();
 
-  String getSubtype();
+  public abstract void setAttributes(Map<String, ? extends Object> attributes);
+
+  public abstract String getType();
+
+  public abstract String getSubtype();
+
+  protected <NewClass extends Object> NewClass getAttribute(Map<String, ? extends Object> attributes, String attributeName, Class<NewClass> clazz) {
+    try {
+      Object object = attributes.get(attributeName);
+
+      if (object == null) return null;
+
+      NewClass castedObject = clazz.cast(object);
+
+      return castedObject;
+    } catch (ClassCastException ex) {
+      throw new IllegalArgumentException(attributeName + " type is invalid, must be " + clazz.getTypeName());
+    }
+  }
 }

--- a/src/main/java/homewatch/things/ThingService.java
+++ b/src/main/java/homewatch/things/ThingService.java
@@ -11,21 +11,19 @@ public abstract class ThingService<T> {
 
   public abstract boolean ping();
 
-  public abstract void setAttributes(Map<String, ? extends Object> attributes);
+  public abstract void setAttributes(Map<String, ?> attributes);
 
   public abstract String getType();
 
   public abstract String getSubtype();
 
-  protected <NewClass extends Object> NewClass getAttribute(Map<String, ? extends Object> attributes, String attributeName, Class<NewClass> clazz) {
+  protected <NewClass> NewClass getAttribute(Map<String, ?> attributes, String attributeName, Class<NewClass> clazz) {
     try {
       Object object = attributes.get(attributeName);
 
       if (object == null) return null;
 
-      NewClass castedObject = clazz.cast(object);
-
-      return castedObject;
+      return clazz.cast(object);
     } catch (ClassCastException ex) {
       throw new IllegalArgumentException(attributeName + " type is invalid, must be " + clazz.getTypeName());
     }

--- a/src/main/java/homewatch/things/lights/HueLightService.java
+++ b/src/main/java/homewatch/things/lights/HueLightService.java
@@ -62,7 +62,7 @@ public class HueLightService extends HttpThingService<Light> {
 
     try {
       this.lightID = Integer.parseInt(lightID);
-    }catch (NumberFormatException ex){
+    } catch (NumberFormatException ex) {
       throw new IllegalArgumentException("light_id must be a number");
     }
   }

--- a/src/main/java/homewatch/things/lights/HueLightService.java
+++ b/src/main/java/homewatch/things/lights/HueLightService.java
@@ -8,6 +8,7 @@ import okhttp3.HttpUrl;
 import org.json.JSONObject;
 
 import java.net.InetAddress;
+import java.util.Map;
 
 public class HueLightService extends HttpThingService<Light> {
   private int lightID;
@@ -49,6 +50,21 @@ public class HueLightService extends HttpThingService<Light> {
     NetUtils.put(HttpUrl.parse(String.format("%s/%d/state", this.baseUrl(), lightID)), json);
 
     return light;
+  }
+
+  @Override
+  public void setAttributes(Map<String, ?> attributes) {
+    super.setAttributes(attributes);
+
+    String lightID = this.getAttribute(attributes, "light_id", String.class);
+
+    if (lightID == null) throw new IllegalArgumentException("missing light_id");
+
+    try {
+      this.lightID = Integer.parseInt(lightID);
+    }catch (NumberFormatException ex){
+      throw new IllegalArgumentException("light_id must be a number");
+    }
   }
 
   @Override

--- a/src/main/java/homewatch/things/weather/OWMWeatherService.java
+++ b/src/main/java/homewatch/things/weather/OWMWeatherService.java
@@ -6,10 +6,11 @@ import homewatch.exceptions.NetworkException;
 import homewatch.things.ThingService;
 import okhttp3.HttpUrl;
 
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.logging.Logger;
 
-class OWMWeatherService implements ThingService<Weather> {
+class OWMWeatherService extends ThingService<Weather> {
   private static final String BASE_URL = "http://api.openweathermap.org/data/2.5/weather?q=%s&APPID=3e7e26039e4050a3edaaf374adb887de";
   private static final HttpUrl REGION_URL = HttpUrl.parse("http://freegeoip.net/json/");
 
@@ -38,6 +39,11 @@ class OWMWeatherService implements ThingService<Weather> {
       Logger.getGlobal().info("FAILED PING REASON:" + e);
       return false;
     }
+  }
+
+  @Override
+  public void setAttributes(Map<String, ?> attributes) {
+    //no attributes to set...
   }
 
   private JsonNode getWeatherData() throws ExecutionException {


### PR DESCRIPTION
Instead of using ``instanceof `` to get the type of an object and get the specific params for it, we shall transform ``ThingService`` to an abstract class, and add a method to every instance called ``setAttributes`` that receives as map as input, and assigns the values of the map to the object instance variables. This map should contains things like address, port, authentication params, etc.

In the service helper we basically pick the query string, convert it to a map, and send those values to this new method, present on every instance of ``ThingService``. Currently, only ``HttpThingService`` implements this method, as `HueLightService` does. In this case, the `HueLightService` calls the method from its superclass before actually setting it's own values (HueLightService extends HttpThingService).